### PR TITLE
Fix test files location path

### DIFF
--- a/TestSuite/simpletap.py
+++ b/TestSuite/simpletap.py
@@ -93,7 +93,7 @@ if "__main__" == __name__:
         totals = [0, 0]
         testenv_tmppath = ""
         if len(sys.argv)>2:
-			testenv_tmppath = sys.argv[2]
+            testenv_tmppath = sys.argv[2]
         for arg in [sys.argv[1]]:
             for dirpath, dirnames, filenames in walktree(arg):
                 for filename in filenames:

--- a/TestSuite/winfstest.py
+++ b/TestSuite/winfstest.py
@@ -54,7 +54,7 @@ def testdone():
     _ntests = 0
 
 def uniqname():
-    return "%08x" % random.randint(1, 2 ** 32)
+    return "%s%08x" % (sys.argv[1], random.randint(1, 2 ** 32))
 
 _fstest_exe = os.path.splitext(os.path.realpath(__file__))[0] + ".exe"
 _field_re = re.compile(r'(?:[^\s"]|"[^"]*")+')


### PR DESCRIPTION
Make it work when using:
run-winfstest.bat . X:\tmp

Also changed tabulations to spaces in simpletap.py.