### PR TITLE
Improvement for Python2.7 Install Path Detection

### DIFF
--- a/TestSuite/run-winfstest.bat
+++ b/TestSuite/run-winfstest.bat
@@ -1,8 +1,15 @@
 @echo off
 
-set PythonRegKey=HKLM\SOFTWARE\Python\PythonCore\2.7
-reg query %PythonRegKey%\InstallPath /ve >nul 2>&1 || (echo Cannot find Windows Python >&2 & exit /b 1)
-for /f "tokens=2,*" %%i in ('reg query %PythonRegKey%\InstallPath /ve ^| findstr Default') do (
+set PythonRegKey=
+set PythonRegKey27Machine=HKLM\SOFTWARE\Python\PythonCore\2.7
+set PythonRegKey27User=HKCU\SOFTWARE\Python\PythonCore\2.7
+
+reg query %PythonRegKey27Machine%\InstallPath /ve >nul 2>&1 && set PythonRegKey=%PythonRegKey27Machine%
+reg query %PythonRegKey27User%\InstallPath /ve >nul 2>&1 && set PythonRegKey=%PythonRegKey27User%
+
+if not defined PythonRegKey (echo Cannot find Windows Python >&2 & exit /b 1)
+
+for /f "tokens=2,*" %%i in ('reg query %PythonRegKey%\InstallPath /ve') do (
     set PythonInstallPath=%%j
 )
 


### PR DESCRIPTION
Fix: run-winfstest.bat detects Python2.7 install path regardless whether machine or single-user install and also language agnostic.