### PR TITLE
Added some tests for truncation behavior of CreateFile (t/base/05.t).

### DIFF
--- a/TestSuite/t/base/05.t
+++ b/TestSuite/t/base/05.t
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 # SetEndOfFile
-# TRUNCATE_EXISTING
+# truncation behavior for TRUNCATE_EXISTING, OPEN_ALWAYS, CREATE_ALWAYS, OPEN_EXISTING
 
 from winfstest import *
 
@@ -19,6 +19,14 @@ expect("CreateFile %s GENERIC_WRITE 0 0 CREATE_ALWAYS FILE_ATTRIBUTE_NORMAL 0" %
 expect("SetEndOfFile %s 42" % name, 0)
 expect("GetFileInformation %s" % name, lambda r: r[0]["FileSize"] == 42)
 expect("CreateFile %s GENERIC_WRITE 0 0 TRUNCATE_EXISTING 0 0" % name, 0)
+expect("GetFileInformation %s" % name, lambda r: r[0]["FileSize"] == 0)
+expect("SetEndOfFile %s 42" % name, 0)
+expect("CreateFile %s GENERIC_READ 0 0 TRUNCATE_EXISTING 0 0" % name, "ERROR_INVALID_PARAMETER")
+expect("CreateFile %s GENERIC_WRITE 0 0 OPEN_ALWAYS FILE_ATTRIBUTE_NORMAL 0" % name, 0)
+expect("GetFileInformation %s" % name, lambda r: r[0]["FileSize"] == 42)
+expect("CreateFile %s GENERIC_WRITE 0 0 OPEN_EXISTING FILE_ATTRIBUTE_NORMAL 0" % name, 0)
+expect("GetFileInformation %s" % name, lambda r: r[0]["FileSize"] == 42)
+expect("CreateFile %s GENERIC_WRITE 0 0 CREATE_ALWAYS FILE_ATTRIBUTE_NORMAL 0" % name, 0)
 expect("GetFileInformation %s" % name, lambda r: r[0]["FileSize"] == 0)
 expect("DeleteFile %s" % name, 0)
 


### PR DESCRIPTION
- Test that disposition TRUNCATE_EXISTING fails with error INVALID_PARAMETER if access mask is not GENERIC_WRITE
- Test that disposition OPEN_ALWAYS does not change the file size of an existing file
- Test that disposition OPEN_EXISTING does not change the file size of an existing file
- Test that disposition CREATE_ALWAYS does reset the file size of an existing file to 0